### PR TITLE
Fix date comparisons during coupon activations

### DIFF
--- a/lidlplus/__main__.py
+++ b/lidlplus/__main__.py
@@ -8,7 +8,7 @@ import os
 import sys
 from getpass import getpass
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 
 if __name__ == "__main__":
     sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -134,9 +134,9 @@ def activate_coupons(args):
         for coupon in section.get("coupons", {}):
             if coupon["isActivated"]:
                 continue
-            if datetime.fromisoformat(coupon["startValidityDate"]) > datetime.now():
+            if datetime.fromisoformat(coupon["startValidityDate"]) > datetime.now(timezone.utc):
                 continue
-            if datetime.fromisoformat(coupon["endValidityDate"]) < datetime.now():
+            if datetime.fromisoformat(coupon["endValidityDate"]) < datetime.now(timezone.utc):
                 continue
             print("activating coupon: ", coupon["title"])
             lidl_plus.activate_coupon(coupon["id"])


### PR DESCRIPTION
Fix the following error on Python 3.11:
```text
Traceback (most recent call last):
  File ".venv/bin/lidl-plus", line 8, in <module>
    sys.exit(start())
             ^^^^^^^
  File "lidlplus/__main__.py", line 162, in start
    main()
  File "lidlplus/__main__.py", line 156, in main
    activate_coupons(args)
  File "lidlplus/__main__.py", line 138, in activate_coupons
    if datetime.fromisoformat(coupon["startValidityDate"]) > datetime.now():
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: can't compare offset-naive and offset-aware datetimes
```