### PR TITLE
Fix: Add missing webdriver dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ oic>=1.4.0
 requests>=2.28.1
 selenium-wire>=5.1.0
 webdriver-manager>=3.8.5
+blinker==1.7.0


### PR DESCRIPTION
Fix for https://github.com/Andre0512/lidl-plus/issues/18. Webdriver is missing dependency https://github.com/seleniumbase/SeleniumBase/issues/2782#issuecomment-2116390901 because of https://github.com/Andre0512/lidl-plus/blob/main/lidlplus/api.py#L34 it was silenced.